### PR TITLE
Integrate FastYIN for stronger Eurydice pitch tracking

### DIFF
--- a/backend/app/music_pitch.py
+++ b/backend/app/music_pitch.py
@@ -1,0 +1,116 @@
+"""Pitch detection helpers for Eurydice."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PitchEstimate:
+    """A pitch estimate returned by the FastYIN-style detector."""
+
+    frequency_hz: float
+    confidence: float
+
+
+def _difference_function(samples: list[float], max_lag: int) -> list[float]:
+    values = [0.0] * (max_lag + 1)
+    sample_length = len(samples)
+    for lag in range(1, max_lag + 1):
+        diff = 0.0
+        upper = sample_length - lag
+        for index in range(upper):
+            delta = samples[index] - samples[index + lag]
+            diff += delta * delta
+        values[lag] = diff
+    return values
+
+
+def _cumulative_mean_normalized_difference(diff_values: list[float]) -> list[float]:
+    normalized = [1.0] * len(diff_values)
+    running_total = 0.0
+    for lag in range(1, len(diff_values)):
+        running_total += diff_values[lag]
+        if running_total <= 0.0:
+            normalized[lag] = 1.0
+            continue
+        normalized[lag] = diff_values[lag] * lag / running_total
+    return normalized
+
+
+def _refine_lag(candidate_lag: int, normalized: list[float]) -> float:
+    if candidate_lag <= 1 or candidate_lag >= len(normalized) - 1:
+        return float(candidate_lag)
+    left = normalized[candidate_lag - 1]
+    center = normalized[candidate_lag]
+    right = normalized[candidate_lag + 1]
+    denominator = left - (2.0 * center) + right
+    if abs(denominator) < 1e-9:
+        return float(candidate_lag)
+    offset = 0.5 * (left - right) / denominator
+    return candidate_lag + max(-0.5, min(0.5, offset))
+
+
+def estimate_pitch_fastyin(
+    samples: list[float],
+    *,
+    sample_rate: int,
+    min_freq: float = 82.41,
+    max_freq: float = 1046.5,
+    threshold: float = 0.12,
+) -> PitchEstimate | None:
+    """Estimate monophonic pitch using a FastYIN-style CMNDF search."""
+    if len(samples) < sample_rate // 20:
+        return None
+
+    mean = sum(samples) / len(samples)
+    centered = [sample - mean for sample in samples]
+    energy = sum(sample * sample for sample in centered)
+    if energy <= 0.0:
+        return None
+
+    min_lag = max(2, int(sample_rate / max_freq))
+    max_lag = min(len(centered) - 1, int(sample_rate / min_freq))
+    if max_lag <= min_lag:
+        return None
+
+    diff_values = _difference_function(centered, max_lag)
+    normalized = _cumulative_mean_normalized_difference(diff_values)
+
+    candidate_lag: int | None = None
+    best_lag = min_lag
+    best_value = normalized[min_lag]
+
+    for lag in range(min_lag, max_lag + 1):
+        value = normalized[lag]
+        if value < best_value:
+            best_value = value
+            best_lag = lag
+
+        if value <= threshold:
+            while lag + 1 <= max_lag and normalized[lag + 1] < value:
+                lag += 1
+                value = normalized[lag]
+            candidate_lag = lag
+            break
+
+    if candidate_lag is None:
+        candidate_lag = best_lag
+
+    refined_lag = _refine_lag(candidate_lag, normalized)
+    if refined_lag <= 0.0:
+        return None
+
+    confidence = max(0.0, min(1.0, 1.0 - normalized[candidate_lag]))
+    if confidence <= 0.0:
+        return None
+
+    frequency_hz = sample_rate / refined_lag
+    if not math.isfinite(frequency_hz) or frequency_hz <= 0.0:
+        return None
+
+    return PitchEstimate(
+        frequency_hz=frequency_hz,
+        confidence=confidence,
+    )

--- a/backend/app/music_transcription.py
+++ b/backend/app/music_transcription.py
@@ -9,6 +9,7 @@ import re
 import struct
 from dataclasses import asdict
 
+from .music_pitch import estimate_pitch_fastyin
 from .music_symbolic import (
     NOTE_NAMES,
     NoteEvent,
@@ -132,38 +133,10 @@ def _find_active_segments(samples: list[float], sample_rate: int) -> list[tuple[
 
 
 def _estimate_pitch(segment: list[float], sample_rate: int) -> tuple[float | None, float]:
-    if len(segment) < sample_rate // 20:
+    estimate = estimate_pitch_fastyin(segment, sample_rate=sample_rate)
+    if estimate is None:
         return None, 0.0
-
-    mean = sum(segment) / len(segment)
-    centered = [sample - mean for sample in segment]
-    energy = sum(sample * sample for sample in centered)
-    if energy <= 0.0:
-        return None, 0.0
-
-    min_freq = 82.41  # E2
-    max_freq = 1046.5  # C6
-    min_lag = max(2, int(sample_rate / max_freq))
-    max_lag = min(len(centered) - 1, int(sample_rate / min_freq))
-    if max_lag <= min_lag:
-        return None, 0.0
-
-    best_lag = 0
-    best_corr = 0.0
-    for lag in range(min_lag, max_lag + 1):
-        corr = 0.0
-        for index in range(len(centered) - lag):
-            corr += centered[index] * centered[index + lag]
-        if corr > best_corr:
-            best_corr = corr
-            best_lag = lag
-
-    if best_lag <= 0 or best_corr <= 0.0:
-        return None, 0.0
-
-    confidence = max(0.0, min(1.0, best_corr / energy))
-    frequency_hz = sample_rate / best_lag
-    return frequency_hz, confidence
+    return estimate.frequency_hz, estimate.confidence
 
 
 def _dedupe_similar_notes(events: list[NoteEvent]) -> list[NoteEvent]:

--- a/backend/tests/test_music_transcription.py
+++ b/backend/tests/test_music_transcription.py
@@ -22,6 +22,7 @@ from app import main as main_module
 from app import music_api as music_api_module
 from app import music_compare as music_compare_module
 from app.music_compare import compare_performance_against_score
+from app.music_pitch import estimate_pitch_fastyin
 from app.music_render import build_note_layout, render_music_score, score_to_musicxml
 from app.music_symbolic import NoteEvent, SymbolicPhrase, import_simple_score
 from app.music_transcription import transcribe_pcm16
@@ -67,6 +68,17 @@ def test_transcribe_pcm16_detects_a4() -> None:
     assert result.notes
     assert result.notes[0].note_name == "A4"
     assert result.confidence > 0.5
+
+
+def test_estimate_pitch_fastyin_detects_a4() -> None:
+    audio_bytes = synth_tone(440.0, duration_ms=700)
+    samples = [sample / 32768.0 for (sample,) in struct.iter_unpack("<h", audio_bytes)]
+
+    estimate = estimate_pitch_fastyin(samples, sample_rate=16000)
+
+    assert estimate is not None
+    assert estimate.confidence > 0.7
+    assert abs(estimate.frequency_hz - 440.0) < 3.0
 
 
 def test_import_simple_score_normalizes_note_line() -> None:


### PR DESCRIPTION
## Summary\n- add a FastYIN-style pitch detector for Eurydice\n- swap the monophonic transcription path over to the new detector\n- add a focused regression test for A4 detection\n\nCloses #11

## Summary by Sourcery

Integrate a FastYIN-style pitch detector into the Eurydice transcription pipeline and update monophonic pitch estimation to use it.

New Features:
- Introduce a dedicated FastYIN-style pitch estimation helper that returns frequency and confidence for monophonic audio segments.

Enhancements:
- Replace the previous autocorrelation-based pitch estimator in the transcription path with the new FastYIN-style detector for more robust A4 detection.

Tests:
- Add a focused regression test to ensure the FastYIN-style pitch estimator reliably detects a 440 Hz (A4) tone with high confidence.