### PR TITLE
Add CREPE-assisted confirmation for Eurydice

### DIFF
--- a/backend/app/music_api.py
+++ b/backend/app/music_api.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field, field_validator
 from . import auth as auth_utils
 from .db import get_db
 from .music_compare import compare_performance_against_score, comparison_to_dict
+from .music_crepe import crepe_runtime_status
 from .models import MusicScore
 from .music_render import render_music_score, verovio_runtime_status
 from .music_symbolic import import_simple_score, score_to_dict
@@ -139,6 +140,8 @@ class MusicRuntimeStatusResponse(BaseModel):
 
     verovio_available: bool
     verovio_detail: str
+    crepe_available: bool
+    crepe_detail: str
 
 
 async def _get_owned_score(db: AsyncSession, score_id: UUID, user_id: str) -> MusicScore:
@@ -178,9 +181,12 @@ async def music_runtime_status(
     del current_user
 
     available, detail = verovio_runtime_status()
+    crepe_available, crepe_detail = crepe_runtime_status()
     return MusicRuntimeStatusResponse(
         verovio_available=available,
         verovio_detail=detail,
+        crepe_available=crepe_available,
+        crepe_detail=crepe_detail,
     )
 
 

--- a/backend/app/music_crepe.py
+++ b/backend/app/music_crepe.py
@@ -1,0 +1,84 @@
+"""Optional CREPE-assisted pitch confirmation for Eurydice."""
+
+from __future__ import annotations
+
+import math
+
+from .music_pitch import PitchEstimate
+
+
+def crepe_runtime_status() -> tuple[bool, str]:
+    """Report whether the optional CREPE stack is importable."""
+    try:
+        import numpy  # noqa: F401
+        import crepe  # noqa: F401
+    except Exception as exc:  # pragma: no cover - depends on optional runtime
+        return False, f"{exc.__class__.__name__}: {exc}"
+    return True, "crepe module detected"
+
+
+def estimate_pitch_crepe(
+    samples: list[float],
+    *,
+    sample_rate: int,
+    step_size_ms: int = 10,
+) -> PitchEstimate | None:
+    """Estimate pitch with CREPE when the optional dependency is installed."""
+    if len(samples) < sample_rate // 20:
+        return None
+
+    try:
+        import numpy as np
+        import crepe
+    except Exception:  # pragma: no cover - depends on optional runtime
+        return None
+
+    audio = np.asarray(samples, dtype=np.float32)
+    if audio.size == 0:
+        return None
+
+    try:
+        _, frequencies, confidences, _ = crepe.predict(
+            audio,
+            sample_rate,
+            viterbi=True,
+            step_size=step_size_ms,
+            verbose=0,
+        )
+    except TypeError:  # pragma: no cover - older crepe signatures
+        try:
+            _, frequencies, confidences, _ = crepe.predict(
+                audio,
+                sample_rate,
+                viterbi=True,
+                step_size=step_size_ms,
+            )
+        except Exception:
+            return None
+    except Exception:  # pragma: no cover - runtime/model errors
+        return None
+
+    weighted_frequency = 0.0
+    total_weight = 0.0
+    best_confidence = 0.0
+    for frequency_hz, confidence in zip(frequencies, confidences):
+        try:
+            frequency_hz = float(frequency_hz)
+            confidence = float(confidence)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(frequency_hz) or frequency_hz <= 0.0:
+            continue
+        if not math.isfinite(confidence) or confidence <= 0.0:
+            continue
+        weighted_frequency += frequency_hz * confidence
+        total_weight += confidence
+        best_confidence = max(best_confidence, confidence)
+
+    if total_weight <= 0.0 or best_confidence <= 0.0:
+        return None
+
+    return PitchEstimate(
+        frequency_hz=weighted_frequency / total_weight,
+        confidence=max(0.0, min(1.0, best_confidence)),
+    )

--- a/backend/app/music_transcription.py
+++ b/backend/app/music_transcription.py
@@ -9,6 +9,7 @@ import re
 import struct
 from dataclasses import asdict
 
+from .music_crepe import estimate_pitch_crepe
 from .music_pitch import estimate_pitch_fastyin
 from .music_symbolic import (
     NOTE_NAMES,
@@ -133,10 +134,26 @@ def _find_active_segments(samples: list[float], sample_rate: int) -> list[tuple[
 
 
 def _estimate_pitch(segment: list[float], sample_rate: int) -> tuple[float | None, float]:
-    estimate = estimate_pitch_fastyin(segment, sample_rate=sample_rate)
-    if estimate is None:
+    fastyin_estimate = estimate_pitch_fastyin(segment, sample_rate=sample_rate)
+    crepe_estimate = estimate_pitch_crepe(segment, sample_rate=sample_rate)
+
+    if fastyin_estimate is None and crepe_estimate is None:
         return None, 0.0
-    return estimate.frequency_hz, estimate.confidence
+    if fastyin_estimate is None:
+        return crepe_estimate.frequency_hz, crepe_estimate.confidence
+    if crepe_estimate is None:
+        return fastyin_estimate.frequency_hz, fastyin_estimate.confidence
+
+    semitone_delta = abs(12.0 * math.log2(crepe_estimate.frequency_hz / fastyin_estimate.frequency_hz))
+    if semitone_delta <= 0.35:
+        blended_frequency = (fastyin_estimate.frequency_hz + crepe_estimate.frequency_hz) / 2.0
+        blended_confidence = max(fastyin_estimate.confidence, crepe_estimate.confidence)
+        return blended_frequency, min(1.0, blended_confidence)
+
+    if crepe_estimate.confidence >= fastyin_estimate.confidence + 0.15:
+        return crepe_estimate.frequency_hz, crepe_estimate.confidence
+
+    return fastyin_estimate.frequency_hz, max(0.0, min(fastyin_estimate.confidence, 0.82))
 
 
 def _dedupe_similar_notes(events: list[NoteEvent]) -> list[NoteEvent]:

--- a/backend/app/static/app.js
+++ b/backend/app/static/app.js
@@ -46,6 +46,7 @@ const appState = {
   clientConfigLoaded: false,
   musicRuntimeLoaded: false,
   verovioAvailable: null,
+  crepeAvailable: null,
   activeMusicScoreId: null,
   activeMusicNotes: [],
   highlightedScoreNoteIndexes: [],
@@ -970,13 +971,21 @@ async function loadMusicRuntimeStatus() {
     }
     const payload = await response.json();
     appState.verovioAvailable = Boolean(payload?.verovio_available);
+    appState.crepeAvailable = Boolean(payload?.crepe_available);
     if (!appState.activeMusicScoreId && !sessionRunning()) {
-      elements.scoreRender.textContent = appState.verovioAvailable
+      const renderStatus = appState.verovioAvailable
         ? "Verovio is available. Render notation will return SVG when a score is loaded."
         : "Verovio is not installed on the backend yet. Render notation will use MusicXML fallback until it is added.";
+      const pitchStatus = appState.crepeAvailable
+        ? " CREPE confirmation is active for focused clips."
+        : " CREPE is not installed yet, so FastYIN remains the only pitch engine.";
+      elements.scoreRender.textContent = `${renderStatus}${pitchStatus}`;
     }
     if (payload?.verovio_detail) {
       console.info(`[${appState.brand}][Verovio]`, payload.verovio_detail);
+    }
+    if (payload?.crepe_detail) {
+      console.info(`[${appState.brand}][CREPE]`, payload.crepe_detail);
     }
   } catch {
     // Keep the default render placeholder when runtime status cannot be loaded.

--- a/backend/requirements-music-ml.txt
+++ b/backend/requirements-music-ml.txt
@@ -1,0 +1,2 @@
+-r requirements-music.txt
+crepe>=0.0.16

--- a/backend/tests/test_music_transcription.py
+++ b/backend/tests/test_music_transcription.py
@@ -21,8 +21,9 @@ from app import db as db_module
 from app import main as main_module
 from app import music_api as music_api_module
 from app import music_compare as music_compare_module
+from app import music_transcription as music_transcription_module
 from app.music_compare import compare_performance_against_score
-from app.music_pitch import estimate_pitch_fastyin
+from app.music_pitch import PitchEstimate, estimate_pitch_fastyin
 from app.music_render import build_note_layout, render_music_score, score_to_musicxml
 from app.music_symbolic import NoteEvent, SymbolicPhrase, import_simple_score
 from app.music_transcription import transcribe_pcm16
@@ -79,6 +80,24 @@ def test_estimate_pitch_fastyin_detects_a4() -> None:
     assert estimate is not None
     assert estimate.confidence > 0.7
     assert abs(estimate.frequency_hz - 440.0) < 3.0
+
+
+def test_estimate_pitch_prefers_crepe_when_it_is_more_confident(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_fastyin(*_args, **_kwargs) -> PitchEstimate:
+        return PitchEstimate(frequency_hz=440.0, confidence=0.52)
+
+    def fake_crepe(*_args, **_kwargs) -> PitchEstimate:
+        return PitchEstimate(frequency_hz=444.0, confidence=0.81)
+
+    monkeypatch.setattr(music_transcription_module, "estimate_pitch_fastyin", fake_fastyin)
+    monkeypatch.setattr(music_transcription_module, "estimate_pitch_crepe", fake_crepe)
+
+    frequency_hz, confidence = music_transcription_module._estimate_pitch([0.0] * 2000, 16000)
+
+    assert abs(frequency_hz - 442.0) < 0.1
+    assert abs(confidence - 0.81) < 0.01
 
 
 def test_import_simple_score_normalizes_note_line() -> None:
@@ -385,6 +404,7 @@ def test_music_runtime_status_endpoint_reports_verovio_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(music_api_module, "verovio_runtime_status", lambda: (False, "verovio missing"))
+    monkeypatch.setattr(music_api_module, "crepe_runtime_status", lambda: (True, "crepe module detected"))
 
     response = client.get(
         "/api/music/runtime",
@@ -396,6 +416,8 @@ def test_music_runtime_status_endpoint_reports_verovio_state(
     assert body == {
         "verovio_available": False,
         "verovio_detail": "verovio missing",
+        "crepe_available": True,
+        "crepe_detail": "crepe module detected",
     }
 
 


### PR DESCRIPTION
## Summary
- add an optional CREPE pitch confirmation module without making it a mandatory backend dependency
- blend FastYIN and CREPE estimates when the second opinion is available and confident
- surface CREPE runtime availability through the Eurydice music runtime status endpoint and client

Closes #13

## Summary by Sourcery

Integrate optional CREPE-based pitch confirmation into the Eurydice music transcription pipeline and surface its runtime availability through the backend API and client UI.

New Features:
- Add a CREPE-based pitch estimation helper that works when the optional dependency stack is installed.
- Expose CREPE runtime availability via the music runtime status API and propagate it to the frontend state and messaging.

Enhancements:
- Blend FastYIN and CREPE pitch estimates to improve robustness and confidence when both engines are available.

Tests:
- Extend music transcription tests to validate CREPE-informed pitch selection logic and runtime status reporting.